### PR TITLE
compatibility with new ini property managment

### DIFF
--- a/fuseki/docker-compose.yml
+++ b/fuseki/docker-compose.yml
@@ -10,8 +10,8 @@ services:
         links:
             - fuseki
         environment:
-            TRIPLESTORE_ENDPOINT: "http://fuseki:3030/database/query"
-            ASKOMICS_LOAD_URL: "http://askomics:6543"
+            ASKO_endpoint: "http://fuseki:3030/database/query"
+            ASKO_load_url: "http://askomics:6543"
         volumes:
             - ./output-container/askomics/ttl/askomics:/tmp
 

--- a/galaxy_virtuoso/docker-compose.yml
+++ b/galaxy_virtuoso/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             - ./output-container/askomics/ttl/askomics:/tmp
 
     virtuoso:
-        image: tenforce/virtuoso
+        image: xgaia/virtuoso
         environment:
             VIRT_Parameters_NumberOfBuffers: 510000
             VIRT_Parameters_MaxDirtyBuffers: 375000

--- a/galaxy_virtuoso/docker-compose.yml
+++ b/galaxy_virtuoso/docker-compose.yml
@@ -5,8 +5,8 @@ services:
         links:
             - virtuoso
         environment:
-            TRIPLESTORE_ENDPOINT: "http://virtuoso:8890/sparql"
-            ASKOMICS_LOAD_URL: "http://askomics:6543"
+            ASKO_endpoint: "http://virtuoso:8890/sparql"
+            ASKO_load_url: "http://askomics:6543"
         volumes:
             - ./output-container/askomics/ttl/askomics:/tmp
 

--- a/virtuoso/docker-compose.yml
+++ b/virtuoso/docker-compose.yml
@@ -8,14 +8,14 @@ services:
         image: askomics/docker-askomics
         command: ./startAskomics.sh -r -t virtuoso -d prod
         environment:
-            TRIPLESTORE_ENDPOINT: "http://virtuoso:8890/sparql"
-            ASKOMICS_LOAD_URL: "http://askomics:6543"
-            ASKOMICS_SMTP_HOST: postfix
-            ASKOMICS_SMTP_PORT: 25
-            ASKOMICS_SMTP_LOGIN: admin
-            ASKOMICS_SMTP_PASSWORD: passasko
-            TRIPLESTORE_ENDPOINT_USERNAME : dba
-            TRIPLESTORE_ENDPOINT_PASSWD : dba
+            ASKO_endpoint: "http://virtuoso:8890/sparql"
+            ASKO_load_url: "http://askomics:6543"
+            ASKO_smtp_host: postfix
+            ASKO_smtp_port: 25
+            ASKO_smtp_login: admin
+            ASKO_smtp_password: passasko
+            ASKO_enpoint_username : dba
+            ASKO_endpoint_passwd : dba
         volumes:
             - ./output-container/askomics/ttl/askomics:/tmp
 

--- a/virtuoso/docker-compose.yml
+++ b/virtuoso/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             - ./output-container/askomics/ttl/askomics:/tmp
 
     virtuoso:
-        image: tenforce/virtuoso
+        image: xgaia/virtuoso
         environment:
             VIRT_Parameters_NumberOfBuffers: 680000
             VIRT_Parameters_MaxDirtyBuffers: 500000


### PR DESCRIPTION
docker-compose use the new ini property managment, describe in PR  askomics/askomics#213

Also use [xgaia/virtuoso](https://github.com/xgaia/docker-virtuoso) instead of  [tenforce/virtuoso](https://github.com/tenforce/docker-virtuoso) (lighter)